### PR TITLE
Fixing test case

### DIFF
--- a/test/org/mxunit/eclipseplugin/actions/RawInvokerTest.java
+++ b/test/org/mxunit/eclipseplugin/actions/RawInvokerTest.java
@@ -3,9 +3,9 @@ package org.mxunit.eclipseplugin.actions;
 import junit.framework.TestCase;
 
 public class RawInvokerTest extends TestCase {
-    RawInvoker invoker = new RawInvoker();
+    RawInvoker invoker;
     public void setUp(){
-        RawInvoker invoker = new RawInvoker();
+        invoker = new RawInvoker();
     }
     
     public void testInitializeCall(){


### PR DESCRIPTION
The test case was wrong cause RawInvoker Object was being created twice (2 different variables) and set up was not being used. Now you just have one variable and set up is doing what it is meant to be doing
